### PR TITLE
Removing undeclared devtools dependency

### DIFF
--- a/R/GetPackage.R
+++ b/R/GetPackage.R
@@ -1,49 +1,20 @@
 
-# Helper to install (if needed) and load a package.
-# if `github == TRUE` then package must be a string like:
-# 'zoonproject/zoon'. Otherwise it's just the package name,
-# either as a string or object.
+# Helper to install (if needed) and load a package,
+# given as the package name, either as a string or object.
 
-GetPackage <- function (package,
-                        github = FALSE) {
+GetPackage <- function (package) {
   
   # convert to string if it isn't already
   package <- as.character(substitute(package))
   
-  # get devtools and chop up the path if it's on github
-  if (github) {
-    
-    # get the whole path
-    package_path <- package
-    
-    # now strip to after the slash so that `library` works
-    package <- strsplit(package_path,
-                              '/')[[1]][2]
-    
-  }
-    
-
   # try loading and install and load if that doesn't work
   if (!require(package,
                character.only = TRUE)) {
     
-    # if it's a github package
-    if (github) {
-      
-      # load devtools (recursively calling GetPackage)
-      GetPackage('devtools',
-                 github = FALSE)
-      
-      install_github(package_path)
-            
-    } else {
-      
-      # otherwise use install.packages
-      install.packages(package,
-                       repos = "http://cran.ma.imperial.ac.uk/")
-      
-    }
-    
+    # otherwise use install.packages
+    install.packages(package,
+                     repos = "http://cran.ma.imperial.ac.uk/")
+
     # now load the package
     library(package,
             character.only = TRUE)


### PR DESCRIPTION
This closes #92. `GetPackage` now no longer handles github-hosted packages and the notes/warnings are cleared up