### PR TITLE
adding Travis CI continuous integration

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@ vignettes/cache
 Notes_for_zoon_developers.md
 zoonDemo.R
 zoonQuickStart.R
+.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: r
+sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ sudo: required
 # R packages not listed in DESCRIPTION, but required for running the tests
 # (i.e. because modules depend on them)
 
+# linux system dependencies for R packages
+apt_packages:
+ - libv8-dev  # for V8 package, for spocc
+
 # these ones have linux binaries available at: https://launchpad.net/~marutter/+archive/ubuntu/c2d4u/ 
 # so they can be loaded much more quickly
 #r_binary_packages:
@@ -32,4 +36,8 @@ r_packages:
  - randomForest
  - mgcv
  - htmlwidgets
+ - covr  # for code test coverage stats
 
+# get code covarage stats for coveralls
+after_success:
+ - Rscript -e 'covr::coveralls()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,21 @@ sudo: required
 # R packages not listed in DESCRIPTION, but required for running the tests
 # (i.e. because modules depend on them)
 
-r_packages:
- - randomForest
- - RNCEP
+# these ones have linux binaries available at: https://launchpad.net/~marutter/+archive/ubuntu/c2d4u/ 
+# so they can be loaded much more quickly
+r_binary_packages:
  - spocc
- - biomod2
+ - SDMTools
+ - RNCEP
  - rfigshare
- - leaflet
+ - randomForest
+ - mgcv
  - htmlwidgets
+
+# these will be built from source, which takes longer
+r_packages:
+ - biomod2
+ - leaflet
  - viridis
  - GRaF
  - sperrorest
- - SDMTools
- - mgcv

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ sudo: required
 
 # these ones have linux binaries available at: https://launchpad.net/~marutter/+archive/ubuntu/c2d4u/ 
 # so they can be loaded much more quickly
-r_binary_packages:
- - spocc
- - SDMTools
- - RNCEP
- - rfigshare
- - randomForest
- - mgcv
- - htmlwidgets
+#r_binary_packages:
+# - spocc
+# - SDMTools
+# - RNCEP
+# - rfigshare
+# - randomForest
+# - mgcv
+# - htmlwidgets
 
 # these will be built from source, which takes longer
 r_packages:
@@ -23,3 +23,13 @@ r_packages:
  - viridis
  - GRaF
  - sperrorest
+ - rgbif
+ - V8
+ - spocc
+ - SDMTools
+ - RNCEP
+ - rfigshare
+ - randomForest
+ - mgcv
+ - htmlwidgets
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,20 @@
+# basic bits:
 language: r
 sudo: required
+
+# R packages not listed in DESCRIPTION, but required for running the tests
+# (i.e. because modules depend on them)
+
+r_packages:
+ - randomForest
+ - RNCEP
+ - spocc
+ - biomod2
+ - rfigshare
+ - leaflet
+ - htmlwidgets
+ - viridis
+ - GRaF
+ - sperrorest
+ - SDMTools
+ - mgcv

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,6 @@ r_packages:
  - sperrorest
  - rgbif
  - V8
- - spocc
- - SDMTools
- - RNCEP
- - rfigshare
- - randomForest
- - mgcv
- - htmlwidgets
  - covr  # for code test coverage stats
 
 # get code covarage stats for coveralls

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/goldingn/zoon.svg)](https://travis-ci.org/goldingn/zoon)
+[![Build Status](https://travis-ci.org/zoonproject/zoon.svg)](https://travis-ci.org/zoonproject/zoon)
 
 # Zoön
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/goldingn/zoon.svg)](https://travis-ci.org/goldingn/zoon)
+
 # Zoön
 
 Zoön is a package for the reproducible and shareable analysis of species distribution models with a focus on the ability to compare between models and diagnostic output of models.


### PR DESCRIPTION
It took a while to set up the yaml, but travis now gets everything installed. The package is failing on tests on R 3.2.2 - but the travis integration is fine, so this closes #22 

Once the package passes, we should have a coveralls test coverage status too, so will add a button for that then.

This is also a step towards #144 since the yaml contains many of the required packages and system requirements for the package and modules. It will need refromatting for docker, but we may then be able to use the docker image for the CI - not sure whether Travis allows that.

A final note - I buggered up my gitconfig playing with docker so those 'rstudio' commits were me ...
