### PR TITLE
Interactive vignette typo

### DIFF
--- a/vignettes/interactive_zoon_usage.Rmd
+++ b/vignettes/interactive_zoon_usage.Rmd
@@ -44,11 +44,11 @@ It's worth noting that this is a simple workflow. Chaining modules will be fairl
 
 Get the modules from the zoon repository and load them into the working environment.
 ```{r LoadModules}
-LoadModule('UKAnophelesPlumbeus')
-LoadModule('UKAir')
-LoadModule('OneHundredBackground')
-LoadModule('LogisticRegression')
-LoadModule('PrintMap')
+LoadModule(UKAnophelesPlumbeus)
+LoadModule(UKAir)
+LoadModule(OneHundredBackground)
+LoadModule(LogisticRegression)
+LoadModule(PrintMap)
 ```
  
 Run the data modules. To chain occurrence modules, just `rbind` the resulting dataframes. To chain covariate modules, use `raster::stack` to combine the covariate data.
@@ -72,7 +72,7 @@ mod <- LogisticRegression(proc$df)
 
 Finally, combine some output into a list and run the output modules.
 ```{r output}
-model <- list(model = mod, df = proc$df)
+model <- list(model = mod, data = proc$df)
 
 out <- PrintMap(model, cov)
 ```
@@ -84,8 +84,8 @@ Crossvalidation requires the modules to be run using the function `zoon:::RunMod
 ```{r cross validation}
 modCrossvalid <- zoon:::RunModels(proc$df, 'LogisticRegression', list(), environment())
 
-modelCrossvalid <- list(model = modCrossvalid$model, df = proc$df)
-
+modelCrossvalid <- list(model = modCrossvalid$model, data = proc$df)
+any(.model$data$value == 0)
 out <- PrintMap(modelCrossvalid, cov)
 ```
 

--- a/vignettes/interactive_zoon_usage.Rmd
+++ b/vignettes/interactive_zoon_usage.Rmd
@@ -85,7 +85,6 @@ Crossvalidation requires the modules to be run using the function `zoon:::RunMod
 modCrossvalid <- zoon:::RunModels(proc$df, 'LogisticRegression', list(), environment())
 
 modelCrossvalid <- list(model = modCrossvalid$model, data = proc$df)
-any(.model$data$value == 0)
 
 out <- PrintMap(modelCrossvalid, cov)
 ```


### PR DESCRIPTION
    model <- list(model = mod, df = proc$df)
to
    model <- list(model = mod, data = proc$df)

I think since we changed some argument names or something this got left behind.