### PR TITLE
Change inputs to output modules

### DIFF
--- a/R/ChangeWorkflow.R
+++ b/R/ChangeWorkflow.R
@@ -271,7 +271,7 @@ ChangeWorkflow <- function(workflow, occurrence = NULL, covariate = NULL, proces
   if (from <= 5) {
     tryCatch({
       output.output <- DoOutputModules(output.module, outputName, 
-                         covariate.module, covariate.output, model.output, e)
+                         process.module, process.output, model.output, e)
       output$report <- output.output
     },  
       error = function(cond){

--- a/R/DoModuleFunctions.R
+++ b/R/DoModuleFunctions.R
@@ -5,49 +5,36 @@
 # If chained, we certainly need to apply over output modules,
 #   AND apply over covariate or model output.
 
-DoOutputModules <- function(output.module, outputName, covariate.module, 
-                     covariate.output, model.output, e) {
+DoOutputModules <- function(output.module, outputName, process.module, 
+                     process.output, model.output, e) {
   # Not chained
   if(!identical(attr(output.module, 'chain'), TRUE)){
+    # if output is a list
     if (length(output.module) > 1){
       output.output <- lapply(outputName, 
                          function(x) do.call(x$func, 
                          c(list(.model = model.output[[1]], 
-                                .ras = covariate.output[[1]]),
+                                .ras = process.output[[1]]$ras),
                            x$paras), envir = e))
 
-    # Actually think that if covariate >1, then model is also >1
-    #   so never need to lapply over covariate?
-    } else if (length(covariate.module) > 1){
-      output.output <- lapply(covariate.output, 
-                         function(x) do.call(outputName[[1]]$func, 
-                         c(list(.model = model.output[[1]],
-                                .ras = x),
-                           outputName[[1]]$paras), envir = e))    
+    # Otherwise model may be parallel. If not, this will still run the 
+    #   single model ok.
     } else {
       output.output <- lapply(model.output, 
                          function(x) do.call(outputName[[1]]$func, 
                          c(list(.model = x,
-                                .ras = covariate.output[[1]]),
+                                .ras = process.output[[1]]$ras),
                            outputName[[1]]$paras), envir = e))
     }
   # Chained
   } else {
-    if (length(covariate.module) > 1){
-      output.output <- lapply(covariate.output, 
-                         function(y) lapply(outputName, 
-                           function(x) do.call(x$func, 
-                           c(list(.model = model.output[[1]],
-                                  .ras = y),
-                             x$paras), envir = e)))    
-    } else {
       output.output <- lapply(model.output, 
                          function(y) lapply(outputName, 
                            function(x) do.call(x$func, 
                            c(list(.model = y,
-                                  .ras = covariate.output[[1]]),
+                                  .ras = process.output[[1]]$ras),
                              x$paras), envir = e)))    
-    }
+    
   }
   return(output.output)
 }

--- a/R/RerunWorkflow.R
+++ b/R/RerunWorkflow.R
@@ -234,7 +234,7 @@ RerunWorkflow <- function(workflow, from = NULL) {
   if (from <= 5) {
     tryCatch({
       output.output <- DoOutputModules(output.module, outputName, 
-                         covariate.module, covariate.output, model.output, e)
+                         process.module, process.output, model.output, e)
       output$report <- output.output
     },  
       error = function(cond){

--- a/R/workflow.R
+++ b/R/workflow.R
@@ -213,7 +213,7 @@ workflow <- function(occurrence, covariate, process, model, output, forceReprodu
   #  Within this need to chain output
   tryCatch({
     output.output <- DoOutputModules(output.module, outputName, 
-                       covariate.module, covariate.output, model.output, e)
+                       process.module, process.output, model.output, e)
     output$report <- output.output
   },  
     error = function(cond){

--- a/vignettes/Building_a_module.Rmd
+++ b/vignettes/Building_a_module.Rmd
@@ -567,7 +567,7 @@ Once we're happy with the module, we will hopefully upload it to the zoon reposi
 
 ## How to write a output module
 
-An output module is the last module in a zoon workflow and is an opportunity to summarise the model results, make predictions, or otherwise visualise the data or results. The input to output modules is a combination of the outputs of occurrence, covariate, process and model modules providing many possible output types.
+An output module is the last module in a zoon workflow and is an opportunity to summarise the model results, make predictions, or otherwise visualise the data or results. The input to output modules is a combination of the outputs of occurrence, process and model modules providing many possible output types.
 
 In this example we will create an output module that uses the model output to predict the species occurrence in a new location given by a user-provided raster.
 

--- a/vignettes/interactive_zoon_usage.Rmd
+++ b/vignettes/interactive_zoon_usage.Rmd
@@ -81,7 +81,7 @@ modCrossvalid <- RunModels(proc$df, 'LogisticRegression', list(), environment())
 
 modelCrossvalid <- list(model = modCrossvalid$model, data = proc$df)
 
-out <- PrintMap(modelCrossvalid, cov)
+out <- PrintMap(modelCrossvalid, proc$ras)
 ```
 
 ## Running workflows with list.


### PR DESCRIPTION
Change workflow and internal functions so that output modules receive rasters from the process modules rather than from the covariate modules.

This means that the covariate data can be altered and used later.

So far this has been used in [MESSMask.R](https://github.com/timcdlucas/modules/blob/f88406eea308bd6fc32e79d19c6faffd4b0422e5/R/MESSMask.R).

But the same ideas would be needed for a PCA modules or a MaxEnt bootstrap variable importance module I think.